### PR TITLE
SQLite support

### DIFF
--- a/lib/also_migrate/migrator.rb
+++ b/lib/also_migrate/migrator.rb
@@ -56,7 +56,7 @@ module AlsoMigrate
                   end
                 else
                   if connection.class.to_s.include?('SQLite')
-                    col_string = connection.columns(old_table).collect {|c|
+                    col_string = connection.columns(config[:source]).collect {|c|
                       "#{c.name} #{c.sql_type}"
                     }.join(', ')
                     connection.execute(<<-SQL)


### PR DESCRIPTION
When the change to `config[:source]` was made, SQLite support seems to have been left behind in the migrator (it was still using `old_table`, which resulted in a `NoMethodError`).  This focused change fixes this issue.
