### PR TITLE
Updated also_migrate to migrate explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,45 +6,50 @@ Migrate multiple tables with similar schema at once.
 Requirements
 ------------
 
-<pre>
-gem install also_migrate
-</pre>
+
+    gem install also_migrate
+
 
 Configure
 ---------
 
-<pre>
-AlsoMigrate.configuration = [
-  {
-    :source => 'articles',
-    :destination => 'article_archives',
-    :add => [
-      # Parameters to ActiveRecord::ConnectionAdapters::SchemaStatements#add_column
-      [ 'deleted_at', :datetime, {} ]
-    ],
-    :subtract => 'restored_at',
-    :ignore => 'deleted_at',
-    :indexes => 'id'
-  },
-  {
-    :source => 'users',
-    :destination => [ 'banned_users', 'deleted_users' ]
-  }
-]
-</pre>
+In your migration:
+
+
+    class CreateArticleArchives < ActiveRecord::Migration
+      def self.up
+        AlsoMigrate.configuration = [
+          {
+            :source => 'articles',
+            :destination => 'article_archives',
+            :add => [
+              # Parameters to ActiveRecord::ConnectionAdapters::SchemaStatements#add_column
+              [ 'deleted_at', :datetime, {} ]
+            ],
+            :subtract => 'restored_at',
+            :ignore => 'deleted_at',
+            :indexes => 'id'
+          },
+          {
+            :source => 'users',
+            :destination => [ 'banned_users', 'deleted_users' ]
+          }
+        ]
+        AlsoMigrate::Migrator.migrate
+      end
+    
+      def self.down
+      end
+    end
 
 Options:
 
-* <code>source</code> Database schema source table
-* <code>destination</code> Database schema destination table (can also be an array of tables)
-* <code>add</code> Create columns that the original table doesn't have (defaults to none)
-* <code>subtract</code> Exclude columns from the original table (defaults to none)
-* <code>ignore</code> Ignore migrations that apply to certain columns (defaults to none)
-* <code>indexes</code> Only index certain columns (duplicates all indexes by default)
+* `source` Database schema source table
+* `destination` Database schema destination table (can also be an array of tables)
+* `add` Create columns that the original table doesn't have (defaults to none)
+* `subtract` Exclude columns from the original table (defaults to none)
+* `ignore` Ignore migrations that apply to certain columns (defaults to none)
+* `indexes` Only index certain columns (duplicates all indexes by default)
 
 That's it!
 ----------
-
-Next time you migrate, <code>article_archives</code> is created if it doesn't exist.
-
-Any new migration applied to <code>articles</code> is automatically applied to <code>article_archives</code>.

--- a/lib/also_migrate.rb
+++ b/lib/also_migrate.rb
@@ -10,6 +10,3 @@ module AlsoMigrate
     attr_accessor :configuration
   end
 end
-
-ActiveRecord::Migrator.send(:include, AlsoMigrate::Migrator)
-ActiveRecord::Migration.send(:include, AlsoMigrate::Migration)

--- a/lib/also_migrate/migrator.rb
+++ b/lib/also_migrate/migrator.rb
@@ -1,75 +1,59 @@
 module AlsoMigrate
-  module Migrator
-    
-    def self.included(base)
-      unless base.included_modules.include?(InstanceMethods)
-        base.send :include, InstanceMethods
-        base.class_eval do
-          alias_method :migrate_without_also_migrate, :migrate
-          alias_method :migrate, :migrate_with_also_migrate
-        end
-      end
+  class Migrator
+    def self.connection
+      ActiveRecord::Base.connection
     end
     
-    module InstanceMethods
-      
-      def migrate_with_also_migrate
-        (::AlsoMigrate.configuration || []).each do |config|
-          AlsoMigrate.create_tables(config)
+    def self.migrate(config = AlsoMigrate.configuration)
+      begin
+        (config || []).each do |c|
+          create_tables(c)
         end
       rescue Exception => e
         puts "AlsoMigrate error: #{e.message}"
         puts e.backtrace.join("\n")
       ensure
-        migrate_without_also_migrate
       end
-      
-      module AlsoMigrate
-        class <<self
-        
-          def connection
-            ActiveRecord::Base.connection
-          end
-        
-          def create_tables(config)
-            [ config[:destination] ].flatten.compact.each do |new_table|
-              if !connection.table_exists?(new_table) && connection.table_exists?(config[:source])
-                columns = connection.columns(config[:source]).collect(&:name)
-                columns -= [ config[:subtract] ].flatten.compact.collect(&:to_s)
-                columns.collect! { |col| connection.quote_column_name(col) }
-                if config[:indexes]
-                  engine =
-                    if connection.class.to_s.include?('Mysql')
-                      'ENGINE=' + connection.select_one(<<-SQL)['Engine']
-                        SHOW TABLE STATUS
-                        WHERE Name = '#{config[:source]}'
-                      SQL
-                    end
-                  connection.execute(<<-SQL)
-                    CREATE TABLE #{new_table} #{engine}
-                    AS SELECT #{columns.join(',')}
-                    FROM #{config[:source]}
-                    WHERE false;
-                  SQL
-                  [ config[:indexes] ].flatten.compact.each do |column|
-                    connection.add_index(new_table, column)
-                  end
-                else
-                  if connection.class.to_s.include?('SQLite')
-                    col_string = connection.columns(old_table).collect {|c|
-                      "#{c.name} #{c.sql_type}"
-                    }.join(', ')
-                    connection.execute(<<-SQL)
-                      CREATE TABLE #{new_table}
-                      (#{col_string})
-                    SQL
-                  else
-                    connection.execute(<<-SQL)
-                      CREATE TABLE #{new_table}
-                      LIKE #{config[:source]};
-                    SQL
-                  end
-                end
+    end
+    
+    def self.create_tables(config)
+      [ config[:destination] ].flatten.compact.each do |new_table|
+        if !connection.table_exists?(new_table) && connection.table_exists?(config[:source])
+          columns = connection.columns(config[:source]).collect(&:name)
+          columns -= [ config[:subtract] ].flatten.compact.collect(&:to_s)
+          columns.collect! { |col| connection.quote_column_name(col) }
+          if config[:indexes]
+            if connection.class.to_s.include?('Mysql')
+              engine = 'ENGINE=' + connection.select_one(<<-SQL)['Engine']
+              SHOW TABLE STATUS
+              WHERE Name = '#{config[:source]}'
+              SQL
+              connection.execute(<<-SQL)
+              CREATE TABLE #{new_table} #{engine}
+              AS SELECT #{columns.join(',')}
+              FROM #{config[:source]}
+              WHERE false;
+              SQL
+            end
+            [ config[:indexes] ].flatten.compact.each do |column|
+              connection.add_index(new_table, column)
+            end
+          else
+            if connection.class.to_s.include?('SQLite')
+              col_string = connection.columns(old_table).collect {|c|
+                "#{c.name} #{c.sql_type}"
+              }.join(', ')
+              connection.execute(<<-SQL)
+              CREATE TABLE #{new_table}
+              (#{col_string})
+               SQL
+             else
+               connection.execute(<<-SQL)
+               CREATE TABLE #{new_table}
+               LIKE #{config[:source]};
+               SQL
+             end
+            end
               end
               if connection.table_exists?(new_table)
                 if config[:add] || config[:subtract]
@@ -92,8 +76,5 @@ module AlsoMigrate
               end
             end
           end
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
Hey guys, 
I updated also_migrate to explicitly perform migrations that users present to the AlsoMigrate.configuration by exposing AlsoMigrate::Migrator.migrate. The reason for doing this is so that developers can easily tie the use this gem into their existing migrations. For instance, we have a sharded db setup and we use the migrations tos to migrate the schema across all of the dbs appropriately. Being explicit also makes it easier to determine which environment (prod/dev/test) is getting migrated. I guess I should have added in a migrate_down method as well...
