### PR TITLE
Postresql fix

### DIFF
--- a/lib/also_migrate/migrator.rb
+++ b/lib/also_migrate/migrator.rb
@@ -64,9 +64,12 @@ module AlsoMigrate
                       (#{col_string})
                     SQL
                   else
+                    # Postgres fix
+                    # "CREATE TABLE XXX LIKE YYY" is invalid
+                    # "CREATE TABLE XXX ( LIKE YYY )" is a correct one
                     connection.execute(<<-SQL)
                       CREATE TABLE #{new_table}
-                      LIKE #{config[:source]};
+                      (LIKE #{config[:source]});
                     SQL
                   end
                 end


### PR DESCRIPTION
For postgres 8.4 sql like this "CREATE TABLE archived_articles LIKE articles" is invalid. 
This is correct one "CREATE TABLE archived_articles (LIKE articles)"

Fixes #5 
