### PR TITLE
Fix for Rails 3.1 Timestamp Generation & Psych YAML Parse Errors

### DIFF
--- a/config/gemsets.yml
+++ b/config/gemsets.yml
@@ -1,4 +1,4 @@
 also_migrate:
-  active_wrapper: =0.4.4
-  rake: >=0.8.7
-  rspec: ~>1.0
+  active_wrapper: "=0.4.4"
+  rake: ">=0.8.7"
+  rspec: "~>1.0"

--- a/lib/also_migrate/migration.rb
+++ b/lib/also_migrate/migration.rb
@@ -17,7 +17,7 @@ module AlsoMigrate
 
       def method_missing_with_also_migrate(method, *arguments, &block)
         args = Marshal.load(Marshal.dump(arguments))
-        method_missing_without_also_migrate(method, *arguments, &block)
+        return_value = method_missing_without_also_migrate(method, *arguments, &block)
 
         supported = [
           :add_column, :add_index, :add_timestamps, :change_column,
@@ -58,6 +58,8 @@ module AlsoMigrate
             end
           end
         end
+        
+        return return_value
       end
     end
   end


### PR DESCRIPTION
Since upgrading to Rails 3.1 migration generation has failed to include the timestamp portion of the filename. This was due to a discarded return value in the method_missing overload used to hook into the migration generator. This patch ensures that the return value is returned to the caller and fixes issues installing via Bundler under Ruby 1.9.x due to Psych parse errors.
