### PR TITLE
Now works with new Rails 3.1 reversible migrations with "change" method

### DIFF
--- a/lib/also_migrate/migration.rb
+++ b/lib/also_migrate/migration.rb
@@ -3,7 +3,6 @@ module AlsoMigrate
     
     def self.included(base)
       unless base.respond_to?(:method_missing_with_also_migrate)
-        puts "INCLUDING INTO:"+base.inspect
         base.class_eval do
           include InstanceMethods
           alias_method :method_missing_without_also_migrate, :method_missing
@@ -17,7 +16,6 @@ module AlsoMigrate
 
       def method_missing_with_also_migrate(method, *arguments, &block)
         args = Marshal.load(Marshal.dump(arguments))
-        puts "I AM:#{self.inspect}"
         return_value = self.method_missing_without_also_migrate(method, *arguments, &block)
 
         supported = [

--- a/lib/also_migrate/migration.rb
+++ b/lib/also_migrate/migration.rb
@@ -3,21 +3,22 @@ module AlsoMigrate
     
     def self.included(base)
       unless base.respond_to?(:method_missing_with_also_migrate)
-        base.extend ClassMethods
+        puts "INCLUDING INTO:"+base.inspect
         base.class_eval do
-          class <<self
-            alias_method :method_missing_without_also_migrate, :method_missing
-            alias_method :method_missing, :method_missing_with_also_migrate
-          end
+          include InstanceMethods
+          alias_method :method_missing_without_also_migrate, :method_missing
+          alias_method :method_missing, :method_missing_with_also_migrate
         end
       end
     end
 
-    module ClassMethods
+    module InstanceMethods
+
 
       def method_missing_with_also_migrate(method, *arguments, &block)
         args = Marshal.load(Marshal.dump(arguments))
-        return_value = method_missing_without_also_migrate(method, *arguments, &block)
+        puts "I AM:#{self.inspect}"
+        return_value = self.method_missing_without_also_migrate(method, *arguments, &block)
 
         supported = [
           :add_column, :add_index, :add_timestamps, :change_column,


### PR DESCRIPTION
Hi guys, I've just modded this gem to work with those new Rails 3.1 migrations that can automagically invert themselves. All I've done is made the gem take over the ActiveRecord::Migration method missing instance method rather than the class method. I hope this is ok!

P.S. This is my first ever contribution to open source code :)
